### PR TITLE
removed code dependency on zlib

### DIFF
--- a/src/MatDataProvider/MatFileReader.fs
+++ b/src/MatDataProvider/MatFileReader.fs
@@ -113,9 +113,11 @@ module MatFileReader =
         
     // make recursive function because of binary reader 
     and decompress (reader: BinaryReader) size =
+        use compressedStream = new MemoryStream(reader.ReadBytes size, 2, size - 6)
+        use decompressor = new DeflateStream(compressedStream, CompressionMode.Decompress)
         use mstream = new MemoryStream()
-        use res = new zlib.ZOutputStream(mstream)
-        res.Write(reader.ReadBytes size, 0, size)
+        decompressor.CopyTo(mstream);
+
         mstream.Position <- 0L
 
         readData (new BinaryReader(mstream))


### PR DESCRIPTION
small tweak to use DeflateStream instead of zlib. We also used zlib in the math.net matlab reader until we realized that we could use DeflateStream by removing the header and checksum. Unit tests pass.
