### PR TITLE
Markdown syntax has changed on Github

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 MatDataProvider
 =======================
   
-####What is it?
+#### What is it?
 
 MatDataProvider is an erased type provider for .mat files (binary MATLAB format files).
 
-####Usage
+#### Usage
 
 Here's a simple example of reading 'simulation.mat' file, where 'parameters' and 'results' 
 are the variables stored there (a struct and array):
@@ -22,18 +22,18 @@ Simulation.parameters.seed
 Simulations.results
 ```
 
-####Limitations
+#### Limitations
 
 This is an initial implementation and certain element types are not supported 
 (e.g. sparse matrices) or not finalized yet (cell arrays). There're some sample .mat files
 in the 'data' folder.
 
-####Build status
+#### Build status
 
 [![Build status](https://ci.appveyor.com/api/projects/status/hb814824p50t9pj2?svg=true)](https://ci.appveyor.com/project/luajalla/matprovider)
 [![Build Status](https://travis-ci.org/fsprojects/matprovider.svg)](https://travis-ci.org/fsprojects/matprovider)
 
-####Links
+#### Links
 
 Mat-file format description ([pdf](http://www.mathworks.com/help/pdf_doc/matlab/matfile_format.pdf))
 


### PR DESCRIPTION
In order for the headers to render correctly, I've added space between `####` and the header text